### PR TITLE
Add orcid account to contacts

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -85,6 +85,11 @@
         <i class="fab fa-github" style="color:#222a3f;"></i> sbnielsen
       </a>
     </p>
+    <p>
+      <a href="https://orcid.org/0000-0002-5031-9373" target="_blank" rel="noopener">
+        <i class="fab fa-orcid" style="color:#A6CE39;"></i> ORCID
+      </a>
+    </p>
     </div>
   </div>
 </body>


### PR DESCRIPTION
This pull request adds a new contact method to the `contact.html` page, providing a link to the user's ORCID profile alongside existing contact options.

Contact information update:

* Added an ORCID profile link with the appropriate icon and styling to the contact section in `contact.html`.